### PR TITLE
Support flexible habit completion targets

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -163,6 +163,7 @@ body {
     var(--color-zinc-100) 65%,
     var(--color-zinc-200)
   );
+  --progress-optional: var(--color-zinc-400);
   --progress-fill-offset: var(--progress-fill-offset-narrow);
 
   position: relative;
@@ -178,6 +179,7 @@ body {
     var(--color-zinc-900) 65%,
     var(--color-zinc-800)
   );
+  --progress-optional: var(--color-zinc-600);
 }
 
 .habit-progress__shape {
@@ -214,6 +216,11 @@ body {
   height: var(--progress-dot-size);
   border-radius: 9999px;
   background: var(--progress-pending);
+}
+
+.habit-progress__step[data-kind="optional"] {
+  border: 2px dashed var(--progress-optional);
+  background: color-mix(in srgb, var(--progress-pending) 35%, transparent);
 }
 
 .habit-progress__fill {

--- a/lib/mmentum/habits/habit.ex
+++ b/lib/mmentum/habits/habit.ex
@@ -3,7 +3,8 @@ defmodule Mmentum.Habits.Habit do
   import Ecto.Changeset
 
   schema "habits" do
-    field :iterations, :integer
+    field :min_completions, :integer
+    field :max_completions, :integer
     field :periodicity, Ecto.Enum, values: [:day, :week, :month], default: :week
     field :name, :string
 
@@ -21,12 +22,27 @@ defmodule Mmentum.Habits.Habit do
     habit
     |> cast(attrs, [
       :name,
-      :iterations,
+      :min_completions,
+      :max_completions,
       :periodicity,
       :momentum_score,
       :momentum_last_updated
     ])
-    |> validate_required([:name, :iterations, :periodicity])
+    |> validate_required([:name, :min_completions, :periodicity])
+    |> validate_number(:min_completions, greater_than: 0, less_than_or_equal_to: 31)
+    |> validate_number(:max_completions, greater_than: 0, less_than_or_equal_to: 31)
+    |> validate_completion_range()
     |> validate_number(:momentum_score, greater_than_or_equal_to: 0, less_than_or_equal_to: 100)
+  end
+
+  defp validate_completion_range(changeset) do
+    min_completions = get_field(changeset, :min_completions)
+    max_completions = get_field(changeset, :max_completions)
+
+    if max_completions <= min_completions do
+      add_error(changeset, :max_completions, "must be greater than the minimum")
+    else
+      changeset
+    end
   end
 end

--- a/lib/mmentum_web/components/habit_components.ex
+++ b/lib/mmentum_web/components/habit_components.ex
@@ -1,0 +1,20 @@
+defmodule MmentumWeb.HabitComponents do
+  use MmentumWeb, :html
+
+  alias Mmentum.Habits.Habit
+
+  attr :habit, Habit, required: true
+
+  @doc """
+  Simple component to display the habit's frequency range
+  """
+  def cadence(assigns) do
+    ~H"""
+    <%= if @habit.max_completions do %>
+      {@habit.min_completions}–{@habit.max_completions} per {@habit.periodicity}
+    <% else %>
+      {@habit.min_completions} per {@habit.periodicity}
+    <% end %>
+    """
+  end
+end

--- a/lib/mmentum_web/live/habit_live/form_component.ex
+++ b/lib/mmentum_web/live/habit_live/form_component.ex
@@ -36,19 +36,49 @@ defmodule MmentumWeb.HabitLive.FormComponent do
 
         <fieldset class="rounded-panel border border-zinc-200 bg-zinc-50/70 p-4 dark:border-zinc-800 dark:bg-zinc-950/70">
           <legend class="px-1 type-label text-zinc-900 dark:text-zinc-100">Cadence</legend>
-          <div class="grid grid-cols-1 gap-3 sm:grid-cols-[9rem_1fr]">
+          <div class={[
+            "grid grid-cols-1 gap-3",
+            if(@has_flexible_target,
+              do: "sm:grid-cols-[9rem_9rem_1fr]",
+              else: "sm:grid-cols-[9rem_1fr]"
+            )
+          ]}>
             <.input
-              field={@form[:iterations]}
+              field={@form[:min_completions]}
               type="number"
-              label="Times"
+              label={if @has_flexible_target, do: "Minimum", else: "Times"}
               max={31}
               min={1}
+            />
+            <.input
+              :if={@has_flexible_target}
+              field={@form[:max_completions]}
+              type="number"
+              label="Maximum"
+              max={31}
+              min={1}
+            />
+            <input
+              :if={!@has_flexible_target}
+              type="hidden"
+              name="habit[max_completions]"
+              value=""
             />
             <.input
               field={@form[:periodicity]}
               type="select"
               label="Per"
               options={[Day: :day, Week: :week, Month: :month]}
+            />
+          </div>
+          <div class="mt-4">
+            <.input
+              id="habit-has-flexible-target"
+              type="checkbox"
+              name="habit[has_flexible_target]"
+              value="true"
+              checked={@has_flexible_target}
+              label="Use a flexible range"
             />
           </div>
         </fieldset>
@@ -72,6 +102,7 @@ defmodule MmentumWeb.HabitLive.FormComponent do
     {:ok,
      socket
      |> assign(assigns)
+     |> assign(:has_flexible_target, not is_nil(habit.max_completions))
      |> assign_form(changeset)}
   end
 
@@ -82,11 +113,37 @@ defmodule MmentumWeb.HabitLive.FormComponent do
       |> Habits.change_habit(habit_params)
       |> Map.put(:action, :validate)
 
-    {:noreply, assign_form(socket, changeset)}
+    {:noreply,
+     socket
+     |> assign(:has_flexible_target, habit_params["has_flexible_target"] == "true")
+     |> assign_form(changeset)}
   end
 
-  def handle_event("save", %{"habit" => habit_params}, socket) do
-    save_habit(socket, socket.assigns.action, habit_params)
+  def handle_event(
+        "save",
+        %{
+          "habit" =>
+            %{
+              "has_flexible_target" => has_flexible_target,
+              "max_completions" => max_completions
+            } = habit_params
+        },
+        socket
+      ) do
+    has_flexible_target = has_flexible_target == "true"
+    socket = assign(socket, :has_flexible_target, has_flexible_target)
+
+    if has_flexible_target and max_completions == "" do
+      changeset =
+        socket.assigns.habit
+        |> Habits.change_habit(habit_params)
+        |> Ecto.Changeset.add_error(:max_completions, "can't be blank")
+        |> Map.put(:action, :validate)
+
+      {:noreply, assign_form(socket, changeset)}
+    else
+      save_habit(socket, socket.assigns.action, habit_params)
+    end
   end
 
   defp save_habit(socket, :edit, habit_params) do

--- a/lib/mmentum_web/live/habit_live/index.ex
+++ b/lib/mmentum_web/live/habit_live/index.ex
@@ -113,8 +113,39 @@ defmodule MmentumWeb.HabitLive.Index do
     end
   end
 
-  defp progress_style(iterations, completed) do
-    total_connections = max(iterations - 1, 1)
+  defp completion_summary(%Habit{max_completions: nil, min_completions: target}, completed) do
+    "#{completed} of #{target} completed"
+  end
+
+  defp completion_summary(
+         %Habit{min_completions: min_completions, max_completions: max_completions},
+         completed
+       ) do
+    required_completed = min(completed, min_completions)
+    optional_completed = max(completed - min_completions, 0)
+    optional_total = max_completions - min_completions
+    required_text = "#{required_completed} of #{min_completions} required completions"
+
+    optional_text =
+      case optional_total do
+        1 -> "1 optional completion"
+        count -> "#{count} optional completions"
+      end
+
+    cond do
+      completed < min_completions ->
+        required_text
+
+      optional_completed == 0 ->
+        "#{required_text}; goal met; #{optional_text} available"
+
+      true ->
+        "#{required_text}; goal met; #{optional_completed} of #{optional_text} completed"
+    end
+  end
+
+  defp progress_style(completion_cap, completed) do
+    total_connections = max(completion_cap - 1, 1)
     completed_connections = min(max(completed - 1, 0), total_connections)
     remaining = if completed == 0, do: 1.0, else: 1 - completed_connections / total_connections
     fill_offset = if completed == 0, do: 0.0, else: remaining
@@ -126,10 +157,6 @@ defmodule MmentumWeb.HabitLive.Index do
       "--progress-fill-offset-desktop: #{Float.round(fill_offset * 44, 4)}px"
     ]
     |> Enum.join("; ")
-  end
-
-  defp progress_state(step, completed) when is_integer(step) and is_integer(completed) do
-    if step <= completed, do: "complete", else: "pending"
   end
 
   defp habit_not_found(socket), do: put_flash(socket, :error, "Habit not found.")

--- a/lib/mmentum_web/live/habit_live/index.html.heex
+++ b/lib/mmentum_web/live/habit_live/index.html.heex
@@ -31,7 +31,12 @@
     id={"habit-#{habit.id}"}
     class="border-b border-zinc-100 pb-10 last:border-0 last:pb-0 dark:border-zinc-900"
   >
-    <% completed = min(length(habit.logs), habit.iterations) %>
+    <% completion_cap = habit.max_completions || habit.min_completions %>
+    <% completed = min(length(habit.logs), completion_cap) %>
+    <% optional_steps =
+      if habit.max_completions,
+        do: (habit.min_completions + 1)..habit.max_completions,
+        else: [] %>
     <div class="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
       <div class="group min-w-0">
         <.link
@@ -48,8 +53,11 @@
       </div>
       <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
         <p class="type-metadata">
-          {habit.iterations} times per {habit.periodicity}
+          <MmentumWeb.HabitComponents.cadence habit={habit} />
         </p>
+        <span :if={completed >= habit.min_completions} class="type-metadata">
+          Goal met
+        </span>
         <span :if={habit.momentum_score > 0} class="type-metadata">
           Momentum {Float.round(habit.momentum_score, 2)}
         </span>
@@ -73,37 +81,38 @@
           class="habit-progress"
           data-completed={completed}
           role="progressbar"
-          aria-label={"#{habit.name} completions"}
+          aria-label={"#{habit.name} required completions"}
           aria-valuemin="0"
-          aria-valuemax={habit.iterations}
-          aria-valuenow={completed}
-          aria-valuetext={"#{completed} of #{habit.iterations} completed"}
-          style={progress_style(habit.iterations, completed)}
+          aria-valuemax={habit.min_completions}
+          aria-valuenow={min(completed, habit.min_completions)}
+          aria-valuetext={completion_summary(habit, completed)}
+          style={progress_style(completion_cap, completed)}
         >
           <span class="habit-progress__shape" aria-hidden="true">
-            <span :if={habit.iterations > 1} class="habit-progress__track"></span>
+            <span :if={completion_cap > 1} class="habit-progress__track"></span>
             <span
-              :for={step <- 1..habit.iterations}
+              :for={step <- 1..completion_cap}
               id={"habit-#{habit.id}-progress-step-#{step}"}
               class="habit-progress__step"
-              data-state={progress_state(step, completed)}
+              data-kind={if step in optional_steps, do: "optional", else: "required"}
+              data-state={if step <= completed, do: "complete", else: "pending"}
             ></span>
           </span>
           <span
             class={[
               "habit-progress__fill",
-              completed > 0 && completed < habit.iterations && "habit-progress__fill--partial"
+              completed > 0 && completed < completion_cap && "habit-progress__fill--partial"
             ]}
             aria-hidden="true"
           >
             <span class="habit-progress__fill-fluid">
               <span
-                :for={_step <- 1..habit.iterations}
+                :for={_step <- 1..completion_cap}
                 class="habit-progress__fill-fluid-step"
               ></span>
             </span>
             <span class="habit-progress__fill-beads">
-              <span :for={_step <- 1..habit.iterations} class="habit-progress__fill-step"></span>
+              <span :for={_step <- 1..completion_cap} class="habit-progress__fill-step"></span>
             </span>
           </span>
         </div>
@@ -130,10 +139,10 @@
           type="button"
           class={[
             "button-feedback h-12 text-zinc-700 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100",
-            completed >= habit.iterations &&
+            completed >= completion_cap &&
               "cursor-not-allowed disabled:text-zinc-200 dark:disabled:text-zinc-800"
           ]}
-          disabled={completed >= habit.iterations}
+          disabled={completed >= completion_cap}
           aria-label={"Record a completion for #{habit.name}"}
           title="Record completion"
         >

--- a/lib/mmentum_web/live/habit_live/show.html.heex
+++ b/lib/mmentum_web/live/habit_live/show.html.heex
@@ -10,8 +10,9 @@
 
 <.list>
   <:item title="Name">{@habit.name}</:item>
-  <:item title="Iterations">{@habit.iterations}</:item>
-  <:item title="Periodicity">{@habit.periodicity}</:item>
+  <:item title="Cadence">
+    <MmentumWeb.HabitComponents.cadence habit={@habit} />
+  </:item>
 </.list>
 
 <section class="mt-12 flow-root">

--- a/priv/repo/migrations/20231025171544_create_habits.exs
+++ b/priv/repo/migrations/20231025171544_create_habits.exs
@@ -5,7 +5,8 @@ defmodule Mmentum.Repo.Migrations.CreateHabits do
     create table(:habits) do
       add :name, :string
       add :periodicity, :string
-      add :iterations, :integer
+      add :min_completions, :integer, null: false
+      add :max_completions, :integer
 
       add :user_id, references(:users, on_delete: :delete_all), null: false
 

--- a/test/mmentum/habits_test.exs
+++ b/test/mmentum/habits_test.exs
@@ -10,7 +10,7 @@ defmodule Mmentum.HabitsTest do
   import Mmentum.AccountsFixtures
   import Mmentum.HabitsFixtures
 
-  @invalid_attrs %{iterations: nil, name: nil, periodicity: nil}
+  @invalid_attrs %{min_completions: nil, name: nil, periodicity: nil}
 
   describe "habits" do
     test "get_habit!/2 returns an owned habit" do
@@ -30,13 +30,41 @@ defmodule Mmentum.HabitsTest do
 
     test "create_habit/2 creates a habit for the user" do
       user = user_fixture()
-      valid_attrs = %{iterations: 42, name: "some name", periodicity: :week}
+      valid_attrs = %{min_completions: 3, name: "some name", periodicity: :week}
 
       assert {:ok, %Habit{} = habit} = Habits.create_habit(user, valid_attrs)
       assert habit.user_id == user.id
-      assert habit.iterations == 42
+      assert habit.min_completions == 3
+      assert habit.max_completions == nil
       assert habit.name == "some name"
       assert habit.periodicity == :week
+    end
+
+    test "create_habit/2 creates a flexible completion range" do
+      user = user_fixture()
+
+      assert {:ok, %Habit{} = habit} =
+               Habits.create_habit(user, %{
+                 min_completions: 2,
+                 max_completions: 3,
+                 name: "Go to the gym",
+                 periodicity: :week
+               })
+
+      assert habit.min_completions == 2
+      assert habit.max_completions == 3
+    end
+
+    test "create_habit/2 rejects a maximum that does not exceed the minimum" do
+      attrs = %{
+        min_completions: 2,
+        max_completions: 2,
+        name: "Go to the gym",
+        periodicity: :week
+      }
+
+      assert {:error, changeset} = Habits.create_habit(user_fixture(), attrs)
+      assert "must be greater than the minimum" in errors_on(changeset).max_completions
     end
 
     test "create_habit/2 returns an error changeset for invalid data" do
@@ -48,9 +76,9 @@ defmodule Mmentum.HabitsTest do
       habit = habit_fixture(user: user)
 
       assert {:ok, %Habit{} = habit} =
-               Habits.update_habit(user, habit.id, %{iterations: 43, name: "updated"})
+               Habits.update_habit(user, habit.id, %{min_completions: 4, name: "updated"})
 
-      assert habit.iterations == 43
+      assert habit.min_completions == 4
       assert habit.name == "updated"
     end
 

--- a/test/mmentum_web/live/habit_live_test.exs
+++ b/test/mmentum_web/live/habit_live_test.exs
@@ -8,9 +8,9 @@ defmodule MmentumWeb.HabitLiveTest do
   import Phoenix.LiveViewTest
   import Mmentum.HabitsFixtures
 
-  @create_attrs %{iterations: 42, name: "some name"}
-  @update_attrs %{iterations: 43, name: "some updated name"}
-  @invalid_attrs %{iterations: nil, name: nil}
+  @create_attrs %{min_completions: 3, name: "some name"}
+  @update_attrs %{min_completions: 4, name: "some updated name"}
+  @invalid_attrs %{min_completions: nil, name: nil}
 
   defp create_habit(%{user: user}) do
     habit = habit_fixture(user: user)
@@ -87,12 +87,14 @@ defmodule MmentumWeb.HabitLiveTest do
 
       assert_patch(index_live, ~p"/habits/new")
 
+      refute has_element?(index_live, "#habit_max_completions")
+
       assert index_live
              |> form("#habit-form", habit: @invalid_attrs)
              |> render_change() =~ "can&#39;t be blank"
 
       assert has_element?(index_live, "#habit_name[aria-invalid=true]")
-      assert has_element?(index_live, "#habit_iterations[aria-invalid=true]")
+      assert has_element?(index_live, "#habit_min_completions[aria-invalid=true]")
 
       assert index_live
              |> form("#habit-form", habit: @create_attrs)
@@ -103,6 +105,82 @@ defmodule MmentumWeb.HabitLiveTest do
       html = render(index_live)
       assert html =~ "Habit created."
       assert html =~ "some name"
+    end
+
+    test "saves a flexible range and treats its maximum as optional", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, ~p"/habits")
+
+      index_live
+      |> element(~s|a[href="/habits/new"]|)
+      |> render_click()
+
+      index_live
+      |> form("#habit-form",
+        habit: %{
+          has_flexible_target: "true",
+          min_completions: 2,
+          name: "Go to the gym",
+          periodicity: "week"
+        }
+      )
+      |> render_change()
+
+      assert has_element?(index_live, "#habit_max_completions")
+
+      assert index_live
+             |> form("#habit-form",
+               habit: %{
+                 has_flexible_target: "true",
+                 max_completions: "",
+                 min_completions: 2,
+                 name: "Go to the gym",
+                 periodicity: "week"
+               }
+             )
+             |> render_submit() =~ "can&#39;t be blank"
+
+      assert has_element?(index_live, "#habit_max_completions[aria-invalid=true]")
+
+      index_live
+      |> form("#habit-form",
+        habit: %{
+          has_flexible_target: "true",
+          max_completions: 3,
+          min_completions: 2,
+          name: "Go to the gym",
+          periodicity: "week"
+        }
+      )
+      |> render_submit()
+
+      assert_patch(index_live, ~p"/habits")
+      html = render(index_live)
+      assert html =~ "2–3 per week"
+
+      habit = Repo.get_by!(Mmentum.Habits.Habit, name: "Go to the gym")
+      progress = "#habit-#{habit.id}-progress"
+      optional_step = "#habit-#{habit.id}-progress-step-3"
+      add_button = ~s|#habit-#{habit.id} button[phx-click="add_log"]|
+
+      assert has_element?(index_live, ~s|#{optional_step}[data-kind="optional"][data-state="pending"]|)
+
+      index_live |> element(add_button) |> render_click()
+      index_live |> element(add_button) |> render_click()
+
+      assert has_element?(index_live, ~s|#{progress}[aria-valuenow="2"][aria-valuemax="2"]|)
+      assert render(index_live) =~ "Goal met"
+      assert has_element?(index_live, "#{add_button}:not([disabled])")
+
+      index_live |> element(add_button) |> render_click()
+
+      assert has_element?(index_live, ~s|#{optional_step}[data-state="complete"]|)
+
+      assert has_element?(
+               index_live,
+               ~s|#{progress}[aria-valuetext="2 of 2 required completions; goal met; 1 of 1 optional completion completed"]|
+             )
+
+      assert has_element?(index_live, "#{add_button}[disabled]")
     end
 
     test "updates habit in listing", %{conn: conn, habit: habit} do
@@ -128,6 +206,51 @@ defmodule MmentumWeb.HabitLiveTest do
       html = render(index_live)
       assert html =~ "Habit updated."
       assert html =~ "some updated name"
+    end
+
+    test "removes a flexible maximum when editing back to an exact target", %{
+      conn: conn,
+      habit: habit,
+      user: user
+    } do
+      {:ok, habit} =
+        Habits.update_habit(user, habit.id, %{min_completions: 2, max_completions: 3})
+
+      {:ok, index_live, _html} = live(conn, ~p"/habits")
+
+      index_live
+      |> element(~s|#habit-#{habit.id} a[href="/habits/#{habit.id}/edit"]|)
+      |> render_click()
+
+      assert has_element?(index_live, "#habit-has-flexible-target[checked]")
+      assert has_element?(index_live, "#habit_max_completions")
+
+      index_live
+      |> form("#habit-form",
+        habit: %{
+          has_flexible_target: "false",
+          min_completions: 2,
+          name: habit.name,
+          periodicity: "week"
+        }
+      )
+      |> render_change()
+
+      refute has_element?(index_live, "#habit_max_completions")
+
+      index_live
+      |> form("#habit-form",
+        habit: %{
+          has_flexible_target: "false",
+          min_completions: 2,
+          name: habit.name,
+          periodicity: "week"
+        }
+      )
+      |> render_submit()
+
+      assert Repo.get!(Mmentum.Habits.Habit, habit.id).max_completions == nil
+      assert render(index_live) =~ "2 per week"
     end
 
     test "shows the habit's current periodicity when editing", %{

--- a/test/support/fixtures/habits_fixtures.ex
+++ b/test/support/fixtures/habits_fixtures.ex
@@ -15,7 +15,7 @@ defmodule Mmentum.HabitsFixtures do
       attrs
       |> Map.drop([:user])
       |> Enum.into(%{
-        iterations: 42,
+        min_completions: 3,
         name: "some name",
         periodicity: :week
       })


### PR DESCRIPTION
Habits can now use a flexible target such as 2–3 times per week instead of forcing one exact count.

- Store a required minimum and optional maximum so exact and flexible targets share one model
- Let people enable a flexible range in the habit form and show the cadence on the dashboard and detail page
- Treat the minimum as goal met while keeping optional completions available through the maximum
- Cover validation, create and edit behavior, and progress states with context and LiveView tests